### PR TITLE
Fix font issues by importing the corresponding css file from google apis

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,6 +86,6 @@ module.exports = {
     ],
   ],
   stylesheets: [
-    "https://fonts.googleapis.com/css?family=Montserrat:100,200,300,400,500,600,700",
+    "https://fonts.googleapis.com/css?family=Inter:100,200,300,400,500,600,700",
   ],
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,4 +85,7 @@ module.exports = {
       },
     ],
   ],
+  stylesheets: [
+    "https://fonts.googleapis.com/css?family=Montserrat:100,200,300,400",
+  ],
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -86,6 +86,6 @@ module.exports = {
     ],
   ],
   stylesheets: [
-    "https://fonts.googleapis.com/css?family=Montserrat:100,200,300,400",
+    "https://fonts.googleapis.com/css?family=Montserrat:100,200,300,400,500,600,700",
   ],
 };

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -9,7 +9,7 @@
   --ifm-color-primary-lighter: #57c6ce;
   --ifm-color-primary-lightest: #b8eaea;
   --ifm-color-feedback-background: #f5f6f6;
-  --ifm-font-family: 'Montserrat';
+  --ifm-font-family-base: 'Inter';
 }
 
 .docusaurus-highlight-code-line {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -9,7 +9,7 @@
   --ifm-color-primary-lighter: #57c6ce;
   --ifm-color-primary-lightest: #b8eaea;
   --ifm-color-feedback-background: #f5f6f6;
-  --ifm-font-family-base: 'Inter';
+  --ifm-font-family: 'Montserrat';
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
# Context

My MAC was not loading fonts as expected

# What does this PR do?

It fixes the issue by importing the CSS file for Inter font from google api

# Evidence

| Before                                                                                                         | After                                                                                                          |
|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/5056411/166732482-422a28a1-76a5-4888-8afc-aea10633fd99.png) | ![image](https://user-images.githubusercontent.com/5056411/166825180-ac9d3783-a17c-45f7-9c13-0690cb35d62c.png)
